### PR TITLE
Post 조회수 관련 로직 수정

### DIFF
--- a/src/main/java/xyz/connect/post/config/ModelMapperConfig.java
+++ b/src/main/java/xyz/connect/post/config/ModelMapperConfig.java
@@ -44,6 +44,7 @@ public class ModelMapperConfig {
                 post.setContent(source.getContent());
                 post.setImages(imageStringToList(source.getImages()));
                 post.setCreatedAt(source.getCreatedAt());
+                post.setViews(source.getViews());
                 return post;
             }
         };

--- a/src/main/java/xyz/connect/post/web/controller/PostController.java
+++ b/src/main/java/xyz/connect/post/web/controller/PostController.java
@@ -19,6 +19,7 @@ import xyz.connect.post.util.AccountInfoUtil;
 import xyz.connect.post.web.model.request.CreatePost;
 import xyz.connect.post.web.model.request.UpdatePost;
 import xyz.connect.post.web.model.response.Post;
+import xyz.connect.post.web.model.response.PostDetail;
 import xyz.connect.post.web.service.PostService;
 
 @RestController
@@ -36,7 +37,7 @@ public class PostController {
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<Post> getPost(@PathVariable Long postId) {
+    public ResponseEntity<PostDetail> getPost(@PathVariable Long postId) {
         return ResponseEntity.ok(postService.getPost(postId));
     }
 
@@ -57,12 +58,6 @@ public class PostController {
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(@PathVariable Long postId, HttpServletRequest request) {
         postService.deletePost(postId, accountInfoUtil.getAccountId(request));
-        return ResponseEntity.noContent().build();
-    }
-
-    @PostMapping("/views/{postId}")
-    public ResponseEntity<Void> increaseViews(@PathVariable Long postId) {
-        postService.increaseViews(postId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/xyz/connect/post/web/entity/PostEntity.java
+++ b/src/main/java/xyz/connect/post/web/entity/PostEntity.java
@@ -29,6 +29,9 @@ public class PostEntity extends BaseEntity {
     @Column(columnDefinition = "text")
     private String images; // 공백없이 ; 를 구분자로 하는 url 목록
 
+    @Column(columnDefinition = "BIGINT")
+    private Long views = 0L;
+
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
     List<CommentEntity> comments = new ArrayList<>();
 }

--- a/src/main/java/xyz/connect/post/web/entity/redis/PostViewsEntity.java
+++ b/src/main/java/xyz/connect/post/web/entity/redis/PostViewsEntity.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
-@RedisHash(value = "postViews")
+@RedisHash(value = "postViews", timeToLive = 3600)
 @Getter
 @Setter
 public class PostViewsEntity {

--- a/src/main/java/xyz/connect/post/web/model/response/Post.java
+++ b/src/main/java/xyz/connect/post/web/model/response/Post.java
@@ -14,4 +14,5 @@ public class Post {
     private String content;
     private List<String> images;
     private Date createdAt;
+    private Long views;
 }

--- a/src/main/java/xyz/connect/post/web/model/response/PostDetail.java
+++ b/src/main/java/xyz/connect/post/web/model/response/PostDetail.java
@@ -1,0 +1,21 @@
+package xyz.connect.post.web.model.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Date;
+import java.util.List;
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PostDetail {
+
+    private Long postId;
+    private Long accountId;
+    private String content;
+    private List<String> images;
+    private Date createdAt;
+    private Long views;
+    @ToString.Exclude
+    private List<Comment> comments;
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치 (필수)
- fix/view_logic

### 💡 작업동기 (선택) 
- 조회수 증가로직이 단순 엔드포인트 호출로 되어있기 때문에 변경
- 단일 포스트를 조회할 때, 조회수가 증가된다.
- 조회수 증가는 매우 빈번하게 일어나기 때문에 Redis 를 이용해 캐싱하여 DB 접근횟수를 줄인다.

### 🔑 주요 변경사항 (필수)
- 포스트를 조회할 때, 캐싱된 조회수를 가져온다.
- 캐싱되어 있지 않으면 새롭게 캐싱한다.
- 조회수 증가는 DB에 바로 UPDATE 하지 않고, Redis 에서만 증가시킨다.
- 조회수 증가는 단일 포스트 조회 엔드포인트에서 만 동작한다. GET /post/{postId}
- 캐싱된 조회수는 Spring Batch 의 스케쥴링을 이용하여 일정시간마다 주기적으로 DB에 기록한다.
