### PR TITLE
S3 이미지 삭제 이벤트 추가

### DIFF
--- a/src/main/java/xyz/connect/post/event/DeletedPostEvent.java
+++ b/src/main/java/xyz/connect/post/event/DeletedPostEvent.java
@@ -1,0 +1,12 @@
+package xyz.connect.post.event;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeletedPostEvent {
+
+    private List<String> images;
+}

--- a/src/main/java/xyz/connect/post/event/PostEventHandler.java
+++ b/src/main/java/xyz/connect/post/event/PostEventHandler.java
@@ -1,0 +1,38 @@
+package xyz.connect.post.event;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import xyz.connect.post.util.S3Util;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class PostEventHandler {
+
+    private final S3Util s3Util;
+
+    @EventListener
+    public void deleteImageFromS3(DeletedPostEvent deletedPostEvent) {
+        deleteImages(deletedPostEvent.getImages());
+    }
+
+    @EventListener
+    public void deleteImageFromS3(UpdatedPostEvent updatedPostEvent) {
+        Set<String> updatedImages = new HashSet<>(updatedPostEvent.getUpdatedImages());
+        List<String> target = updatedPostEvent.getOriginalImages().stream()
+                .filter(o -> !updatedImages.contains(o))
+                .toList();
+
+        deleteImages(target);
+    }
+
+    private void deleteImages(List<String> images) {
+        images.forEach(s3Util::deleteFile);
+        log.info("[Event] " + images.size() + "개 이미지 삭제 완료");
+    }
+}

--- a/src/main/java/xyz/connect/post/event/UpdatedPostEvent.java
+++ b/src/main/java/xyz/connect/post/event/UpdatedPostEvent.java
@@ -1,0 +1,13 @@
+package xyz.connect.post.event;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdatedPostEvent {
+
+    private List<String> originalImages;
+    private List<String> updatedImages;
+}

--- a/src/main/java/xyz/connect/post/validator/CheckContentType.java
+++ b/src/main/java/xyz/connect/post/validator/CheckContentType.java
@@ -9,8 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Documented
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE,
-        ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = {FileListValidator.class})
 public @interface CheckContentType {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치 (필수)
- feat/delete_image_event

### 💡 작업동기 (선택) 
- 포스트 이미지를 업로드 하고, 포스트를 삭제 하면 이미지는 더 이상 사용하지 않지만, S3에는 남아있게 되기 때문에 스토리지가 낭비됨

### 🔑 주요 변경사항 (필수)
- DeletedPostEvent, UpdatedPostEvent 추가
- Post 수정 시, 이미지를 더 이상 사용하지 않는지 체크 후 삭제
- Post 삭제 시, 모든 이미지 삭제
