### PR TITLE
fix: 매핑 버그 수정

### DIFF
--- a/src/main/java/xyz/connect/post/web/controller/PostController.java
+++ b/src/main/java/xyz/connect/post/web/controller/PostController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import xyz.connect.post.util.AccountInfoUtil;
 import xyz.connect.post.web.model.request.CreatePost;
@@ -22,6 +23,7 @@ import xyz.connect.post.web.model.response.Post;
 import xyz.connect.post.web.service.PostService;
 
 @RestController
+@RequestMapping("/post")
 @RequiredArgsConstructor
 public class PostController {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
 server:
   servlet:
-    context-path: /api/v1/post
+    context-path: /api/v1
 
 cloud:
   aws:


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치 (필수)
- fix/post_api_mapping

### 💡 작업동기 (선택) 
- 배포환경에서 GET /post 요청이 가지 않고, GET /post/ 만 되는 버그 수정

### 🔑 주요 변경사항 (필수)
- default context: /api/v1/post -> /api/v1
- PostController: @RequestMapping("/post") 추가

### 관련 이슈 (선택)
스프링 자체 버그인 듯 하다. 로컬에서는 제대로 동작하나 배포환경에서는 제대로 동작하지 않는다.
위와 같이 매핑 설정을 나누어 주니 해결되었다.
